### PR TITLE
Add additional flags to the `bookmarks all` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,21 @@ the configuration file and override them via environment variables.
 
 ## Managing Bookmarks
 
-* Getting all unarchiveds bookmarks: `$ linkding bookmarks all`
-* Getting all archived bookmarks: `$ linkding bookmarks all --archived`
+* Get all unarchived bookmarks: `$ linkding bookmarks all`
+* Get all archived bookmarks: `$ linkding bookmarks all --archived`
+
+Both of these commands can have any of three additional options:
+
+* `--query QUERY`: a query to filter results with
+* `--limit LIMIT`: the total number of results to return
+* `--offset OFFSET`: the index from which to return results (e.g., `5` starts at the
+  fifth bookmark)
+
+For example:
+
+* Get all bookmarks and limit to 10 results: `$ linkding bookmarks all --limit 10`
+* Get all archived bookmarks that contain "software": `$ linkding bookmarks all
+  --archived --query software`
 
 ## Managing Tags
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,11 @@ the following order:
 This allows you to mix and match sources – for instance, you might have "defaults" in
 the configuration file and override them via environment variables.
 
-## Managing Bookmarks
+## Bookmarks
+
+### Getting Bookmarks
+
+There are two primary commands to get bookmarks:
 
 * Get all unarchived bookmarks: `$ linkding bookmarks all`
 * Get all archived bookmarks: `$ linkding bookmarks all --archived`
@@ -142,7 +146,7 @@ For example:
 * Get all archived bookmarks that contain "software": `$ linkding bookmarks all
   --archived --query software`
 
-## Managing Tags
+## Tags
 
 TBD
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Configuration can be provided via a variety of sources:
 
 ### Available Parameters
 
+Information about available parameters can be found via the `--help` CLI option (either on
+the main `linkding` executable or on any of its commands):
+
 ```
 $ linkding --help
 Usage: linkding [OPTIONS] COMMAND [ARGS]...

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 - [Python Versions](#python-versions)
 - [Usage](#usage)
   * [Configuration Parameters](#configuration-parameters)
-  * [Managing Bookmarks](#managing-bookmarks)
-  * [Managing Tags](#managing-tags)
+  * [Bookmarks](#bookmarks)
+  * [Tags](#tags)
   * [Misc.](#misc)
 - [Contributing](#contributing)
 
@@ -44,9 +44,6 @@ Configuration can be provided via a variety of sources:
 * Configuration File
 
 ### Available Parameters
-
-Information about available parameters can be found via the `--help` CLI option (either on
-the main `linkding` executable or on any of its commands):
 
 ```
 $ linkding --help

--- a/linkding_cli/commands/bookmark/all.py
+++ b/linkding_cli/commands/bookmark/all.py
@@ -1,11 +1,19 @@
 """Define the bookmarks all command."""
+from __future__ import annotations
+
 import asyncio
 import json
+from typing import Any
 
 from aiolinkding.errors import LinkDingError
 import typer
 
+from linkding_cli.const import CONF_LIMIT, CONF_OFFSET, CONF_QUERY
 from linkding_cli.helpers.decorator import log_exception
+
+
+async def async_get_all_bookmarks() -> dict[str, Any]:
+    """Get all bookmarks."""
 
 
 @log_exception(LinkDingError)
@@ -17,12 +25,40 @@ def get_all(
         "-a",
         help="Return archived bookmarks.",
     ),
+    limit: int = typer.Option(
+        None,
+        "--limit",
+        "-l",
+        help="The number of bookmarks to return.",
+    ),
+    offset: int = typer.Option(
+        None,
+        "--offset",
+        "-o",
+        help="The index from which to return results.",
+    ),
+    query: str = typer.Option(
+        None,
+        "--query",
+        "-q",
+        help="Return bookmarks containing a query string.",
+    ),
 ) -> None:
     """Get all bookmarks."""
+    kwargs = {}
+
+    for param, conf_key in (
+        (limit, CONF_LIMIT),
+        (offset, CONF_OFFSET),
+        (query, CONF_QUERY),
+    ):
+        if param:
+            kwargs[conf_key] = param
+
     if archived:
-        coro = ctx.obj.client.bookmarks.async_get_archived()
+        coro = ctx.obj.client.bookmarks.async_get_archived(**kwargs)
     else:
-        coro = ctx.obj.client.bookmarks.async_get_all()
+        coro = ctx.obj.client.bookmarks.async_get_all(**kwargs)
     data = asyncio.run(coro)
     typer.echo(json.dumps(data))
 

--- a/linkding_cli/const.py
+++ b/linkding_cli/const.py
@@ -1,5 +1,8 @@
 """Define package constants."""
 CONF_CONFIG = "config"
+CONF_LIMIT = "limit"
+CONF_OFFSET = "offset"
+CONF_QUERY = "query"
 CONF_TOKEN = "token"
 CONF_URL = "url"
 CONF_VERBOSE = "verbose"

--- a/linkding_cli/main.py
+++ b/linkding_cli/main.py
@@ -58,5 +58,5 @@ def main(
 
 
 APP = typer.Typer(callback=main)
-APP.add_typer(BOOKMARK_APP, name="bookmarks", help="Manage bookmarks")
-APP.add_typer(TAG_APP, name="tags", help="Manage tags")
+APP.add_typer(BOOKMARK_APP, name="bookmarks", help="Work with bookmarks.")
+APP.add_typer(TAG_APP, name="tags", help="Work with tags.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ packages = [
 
 [tool.poetry.dependencies]
 "ruamel.yaml" = "^0.17.21"
-aiolinkding = ">=2022.5.0"
+aiolinkding = ">=2022.5.1"
 python = "^3.8.0"
 typer = {extras = ["all"], version = "^0.4.1"}
 

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -18,6 +18,10 @@ from linkding_cli.main import APP
             ["bookmarks", "all", "--archived"],
             "aiolinkding.bookmark.BookmarkManager.async_get_archived",
         ),
+        (
+            ["bookmarks", "all", "--query", "test"],
+            "aiolinkding.bookmark.BookmarkManager.async_get_all",
+        ),
     ],
 )
 def test_bookmark_commands(args, patched_api_coro, runner):
@@ -38,6 +42,10 @@ def test_bookmark_commands(args, patched_api_coro, runner):
         (
             ["bookmarks", "all", "--archived"],
             "aiolinkding.bookmark.BookmarkManager.async_get_archived",
+        ),
+        (
+            ["bookmarks", "all", "--query", "test"],
+            "aiolinkding.bookmark.BookmarkManager.async_get_all",
         ),
     ],
 )


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds three additional options to the `bookmarks all` command:

* `--query QUERY`: a query to filter results with
* `--limit LIMIT`: the total number of results to return
* `--offset OFFSET`: the index from which to return results (e.g., `5` starts at the fifth bookmark)

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
