### PR TITLE
Make debug logger less automagical

### DIFF
--- a/linkding_cli/commands/bookmark.py
+++ b/linkding_cli/commands/bookmark.py
@@ -137,9 +137,10 @@ def get_by_id(
 @log_exception()
 def main(ctx: typer.Context) -> None:
     """Interact with bookmarks."""
-    debug(ctx, f"Command: {ctx.invoked_subcommand}")
-    debug(ctx, f"Arguments: {ctx.args}")
-    debug(ctx, f"Options: {ctx.params}")
+    if ctx.obj.config.verbose:
+        debug(f"Command: {ctx.invoked_subcommand}")
+        debug(f"Arguments: {ctx.args}")
+        debug(f"Options: {ctx.params}")
 
 
 BOOKMARK_APP = typer.Typer(callback=main)

--- a/linkding_cli/helpers/logging.py
+++ b/linkding_cli/helpers/logging.py
@@ -14,10 +14,8 @@ def error(msg: str) -> None:
     typer.echo(f"Error: {msg}", err=True)
 
 
-def debug(ctx: typer.Context, msg: str) -> None:
+def debug(msg: str) -> None:
     """Log a debug message."""
-    if not ctx.obj.config.verbose:
-        return
     typer.echo(f"Debug: {msg}")
 
 

--- a/linkding_cli/main.py
+++ b/linkding_cli/main.py
@@ -51,10 +51,11 @@ def main(
 ) -> None:
     """Interact with a linkding instance."""
     ctx.obj = LinkDing(ctx.params)
-    debug(ctx, f"Config: {ctx.obj.config}")
-    debug(ctx, f"Command: {ctx.invoked_subcommand}")
-    debug(ctx, f"Arguments: {ctx.args}")
-    debug(ctx, f"Options: {ctx.params}")
+    if ctx.obj.config.verbose:
+        debug(f"Config: {ctx.obj.config}")
+        debug(f"Command: {ctx.invoked_subcommand}")
+        debug(f"Arguments: {ctx.args}")
+        debug(f"Options: {ctx.params}")
 
 
 APP = typer.Typer(callback=main)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -91,12 +91,11 @@ def test_url_and_token_via_env_vars(runner):
     assert f"<Config token={TEST_TOKEN} url={TEST_URL} verbose=True" in result.stdout
 
 
-def test_verbose_logging(runner):
+@pytest.mark.parametrize("args", [["bookmarks"], ["bookmarks", "all"]])
+def test_verbose_logging(args, runner):
     """Test verbose logging."""
-    result = runner.invoke(APP, ["bookmarks"])
-    assert not any(
-        line for line in result.stdout.rstrip().split("\n") if "Debug" in line
-    )
+    result = runner.invoke(APP, args)
+    assert "Debug" not in result.stdout
 
-    result = runner.invoke(APP, ["-v", "bookmarks"])
-    assert any(line for line in result.stdout.rstrip().split("\n") if "Debug" in line)
+    result = runner.invoke(APP, ["-v"] + args)
+    assert "Debug" in result.stdout


### PR DESCRIPTION
**Describe what the PR does:**

The internal `debug` logging helper was too automagical. This PR makes its use clearer and more like the `info` helper.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
