### PR TITLE
Add CLI command to update a bookmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
     + [The `bookmarks create` command](#the-bookmarks-create-command)
     + [The `bookmarks delete` command](#the-bookmarks-delete-command)
     + [The `bookmarks get` command](#the-bookmarks-get-command)
+    + [The `bookmarks update` command](#the-bookmarks-update-command)
   * [Tags](#tags)
   * [Misc.](#misc)
     + [Parsing and Pretty Printing Data](#parsing-and-pretty-printing-data)
@@ -232,8 +233,36 @@ Options:
 #### Examples:
 
 ```sh
-# Get the bookmark with an ID of 12:
+# Get bookmark 12:
 $ linkding bookmarks get 12
+```
+
+### The `bookmarks update` command
+
+```
+Usage: linkding bookmarks update [OPTIONS] BOOKMARK_ID
+
+  Update a bookmark.
+
+Arguments:
+  BOOKMARK_ID  The ID of a bookmark to update.  [required]
+
+Options:
+  -u, --url URL                  The URL to assign to the bookmark.
+  -d, --description DESCRIPTION  The description to give the bookmark.
+  --tags TAG1,TAG2,...           The tags to apply to the bookmark.
+  -t, --title TITLE              The title to give the bookmark.
+  --help                         Show this message and exit.
+  ```
+
+#### Examples:
+
+```sh
+# Update a bookmark with a new url:
+$ linkding bookmarks update 12 -u https://example.com
+
+# Update a bookmark with title, description, and tags:
+$ linkding bookmarks update 12 -t Example -d "A description" --tags tag1,tag2
 ```
 
 ## Tags

--- a/linkding_cli/commands/bookmark.py
+++ b/linkding_cli/commands/bookmark.py
@@ -34,14 +34,25 @@ def create_or_update(
     else:
         tags = None
 
-    api_kwargs = generate_api_payload(
-        (
-            (CONF_TITLE, title),
-            (CONF_DESCRIPTION, description),
-            (CONF_TAG_NAMES, tags),
+    if bookmark_id:
+        api_kwargs = generate_api_payload(
+            (
+                (CONF_URL, url),
+                (CONF_TITLE, title),
+                (CONF_DESCRIPTION, description),
+                (CONF_TAG_NAMES, tags),
+            )
         )
-    )
-    api_func = partial(ctx.obj.client.bookmarks.async_create, url)
+        api_func = partial(ctx.obj.client.bookmarks.async_update, bookmark_id)
+    else:
+        api_kwargs = generate_api_payload(
+            (
+                (CONF_TITLE, title),
+                (CONF_DESCRIPTION, description),
+                (CONF_TAG_NAMES, tags),
+            )
+        )
+        api_func = partial(ctx.obj.client.bookmarks.async_create, url)
 
     data = asyncio.run(api_func(**api_kwargs))
     typer.echo(json.dumps(data))
@@ -153,8 +164,52 @@ def main(ctx: typer.Context) -> None:
         debug(f"Options: {ctx.params}")
 
 
+@log_exception()
+def update(
+    ctx: typer.Context,
+    bookmark_id: int = typer.Argument(..., help="The ID of a bookmark to update."),
+    url: str = typer.Option(
+        None,
+        "--url",
+        "-u",
+        help="The URL to assign to the bookmark.",
+        metavar="URL",
+    ),
+    description: str = typer.Option(
+        None,
+        "--description",
+        "-d",
+        help="The description to give the bookmark.",
+        metavar="DESCRIPTION",
+    ),
+    tag_names: str = typer.Option(
+        None,
+        "--tags",
+        help="The tags to apply to the bookmark.",
+        metavar="TAG1,TAG2,...",
+    ),
+    title: str = typer.Option(
+        None,
+        "--title",
+        "-t",
+        help="The title to give the bookmark.",
+        metavar="TITLE",
+    ),
+) -> None:
+    """Update a bookmark."""
+    return create_or_update(
+        ctx,
+        bookmark_id=bookmark_id,
+        url=url,
+        description=description,
+        tag_names=tag_names,
+        title=title,
+    )
+
+
 BOOKMARK_APP = typer.Typer(callback=main)
 BOOKMARK_APP.command(name="all")(get_all)
 BOOKMARK_APP.command(name="create")(create)
 BOOKMARK_APP.command(name="delete")(delete)
 BOOKMARK_APP.command(name="get")(get_by_id)
+BOOKMARK_APP.command(name="update")(update)

--- a/linkding_cli/commands/bookmark.py
+++ b/linkding_cli/commands/bookmark.py
@@ -197,6 +197,9 @@ def update(
     ),
 ) -> None:
     """Update a bookmark."""
+    if all(val is None for val in (url, description, tag_names, title)):
+        raise ValueError("Cannot update a bookmark with passing at least one option.")
+
     return create_or_update(
         ctx,
         bookmark_id=bookmark_id,

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -157,12 +157,28 @@ BOOKMARKS_SINGLE_RESPONSE = {
             BOOKMARKS_SINGLE_RESPONSE,
             json.dumps(BOOKMARKS_SINGLE_RESPONSE),
         ),
+        (
+            ["bookmarks", "update", "12", "-u", "https://example.com"],
+            "aiolinkding.bookmark.BookmarkManager.async_update",
+            [12],
+            {"url": "https://example.com"},
+            BOOKMARKS_SINGLE_RESPONSE,
+            json.dumps(BOOKMARKS_SINGLE_RESPONSE),
+        ),
+        (
+            ["bookmarks", "update", "12", "-t", "Updated Title"],
+            "aiolinkding.bookmark.BookmarkManager.async_update",
+            [12],
+            {"title": "Updated Title"},
+            BOOKMARKS_SINGLE_RESPONSE,
+            json.dumps(BOOKMARKS_SINGLE_RESPONSE),
+        ),
     ],
 )
-def test_bookmark_commands(
+def test_bookmark_command_api_calls(
     args, api_coro, api_coro_args, api_coro_kwargs, api_output, runner, stdout_output
 ):
-    """Test various `linkding bookmarks` commands (success and error)."""
+    """Test various `linkding bookmarks` commands/API calls (success and error)."""
     with patch(api_coro, AsyncMock(return_value=api_output)) as mocked_api_call:
         result = runner.invoke(APP, args)
         mocked_api_call.assert_awaited_with(*api_coro_args, **api_coro_kwargs)
@@ -172,3 +188,9 @@ def test_bookmark_commands(
         result = runner.invoke(APP, args)
         mocked_api_call.assert_awaited_with(*api_coro_args, **api_coro_kwargs)
     assert "Error" in result.stdout
+
+
+def test_update_no_options(runner):
+    """Test that attempting to update a bookmark with no options fails."""
+    result = runner.invoke(APP, ["bookmarks", "update", "12"])
+    assert "Cannot update a bookmark with passing at least one option." in result.stdout


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds a CLI command to update a bookmark.

Note that for this to work successfully, https://github.com/sissbruecker/linkding/pull/269 within linkding needs to be merged.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
