### PR TITLE
Bump minimum aiolinkding to 2022.05.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ packages = [
 
 [tool.poetry.dependencies]
 "ruamel.yaml" = "^0.17.21"
-aiolinkding = ">=2022.5.1"
+aiolinkding = ">=2022.5.2"
 python = "^3.8.0"
 typer = {extras = ["all"], version = "^0.4.1"}
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR bumps the minimum version of `aiolinkding` to 2022.05.2.

Changelog: https://github.com/bachya/aiolinkding/releases/tag/2022.05.2
Diff: https://github.com/bachya/aiolinkding/compare/2022.05.1...2022.05.2

**Does this fix a specific issue?**

Fixes https://github.com/bachya/linkding-cli/issues/<ISSUE ID>

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
