### PR TITLE
Add ability to mark new/existing bookmarks as unread

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ Options:
   -d, --description DESCRIPTION  The description to give the bookmark.
   --tags TAG1,TAG2,...           The tags to apply to the bookmark.
   -t, --title TITLE              The title to give the bookmark.
+  -u, --unread                   Whether the newly-created bookmark should be
+                                 marked as unread.
   --help                         Show this message and exit.
   ```
 
@@ -310,6 +312,8 @@ Options:
   -d, --description DESCRIPTION  The description to give the bookmark.
   --tags TAG1,TAG2,...           The tags to apply to the bookmark.
   -t, --title TITLE              The title to give the bookmark.
+  -u, --unread                   Whether the bookmark should be marked as
+                                 unread.
   --help                         Show this message and exit.
   ```
 

--- a/linkding_cli/commands/bookmark.py
+++ b/linkding_cli/commands/bookmark.py
@@ -15,6 +15,7 @@ CONF_DESCRIPTION = "description"
 CONF_QUERY = "query"
 CONF_TAG_NAMES = "tag_names"
 CONF_TITLE = "title"
+CONF_UNREAD = "unread"
 CONF_URL = "url"
 
 
@@ -58,6 +59,12 @@ def create(
         help="The title to give the bookmark.",
         metavar="TITLE",
     ),
+    unread: bool = typer.Option(
+        False,
+        "--unread",
+        "-u",
+        help="Whether the newly-created bookmark should be marked as unread.",
+    ),
 ) -> None:
     """Create a bookmark."""
     if tag_names:
@@ -71,6 +78,7 @@ def create(
             (CONF_DESCRIPTION, description),
             (CONF_TAG_NAMES, tags),
             (CONF_TITLE, title),
+            (CONF_UNREAD, unread),
         )
     )
 
@@ -191,6 +199,12 @@ def update(
         help="The title to give the bookmark.",
         metavar="TITLE",
     ),
+    unread: bool = typer.Option(
+        False,
+        "--unread",
+        "-u",
+        help="Whether the bookmark should be marked as unread.",
+    ),
 ) -> None:
     """Update a bookmark by its linkding ID."""
     if all(val is None for val in (url, description, tag_names, title)):
@@ -206,6 +220,7 @@ def update(
             (CONF_DESCRIPTION, description),
             (CONF_TAG_NAMES, tags),
             (CONF_TITLE, title),
+            (CONF_UNREAD, unread),
             (CONF_URL, url),
         )
     )

--- a/linkding_cli/commands/bookmark.py
+++ b/linkding_cli/commands/bookmark.py
@@ -62,7 +62,6 @@ def create(
     unread: bool = typer.Option(
         False,
         "--unread",
-        "-u",
         help="Whether the newly-created bookmark should be marked as unread.",
     ),
 ) -> None:
@@ -202,14 +201,10 @@ def update(
     unread: bool = typer.Option(
         False,
         "--unread",
-        "-u",
         help="Whether the bookmark should be marked as unread.",
     ),
 ) -> None:
     """Update a bookmark by its linkding ID."""
-    if all(val is None for val in (url, description, tag_names, title)):
-        raise ValueError("Cannot update a bookmark with passing at least one option.")
-
     if tag_names:
         tags = tag_names.split(",")
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ packages = [
 
 [tool.poetry.dependencies]
 "ruamel.yaml" = "^0.17.21"
-aiolinkding = ">=2022.05.2"
+aiolinkding = ">=2022.7.0"
 python = "^3.8.0"
 typer = {extras = ["all"], version = "^0.4.1"}
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,7 +4,7 @@ import json
 from linkding_cli.const import CONF_TOKEN, CONF_URL, CONF_VERBOSE
 
 TEST_TOKEN = "abcde_1234"
-TEST_URL = "http://127.0.0.1:800"
+TEST_URL = "http://127.0.0.1:8080"
 
 TEST_RAW_JSON = json.dumps(
     {

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -19,6 +19,8 @@ BOOKMARKS_ALL_RESPONSE = {
             "description": "Example description",
             "website_title": "Website title",
             "website_description": "Website description",
+            "is_archived": False,
+            "unread": False,
             "tag_names": ["tag1", "tag2"],
             "date_added": "2020-09-26T09:46:23.006313Z",
             "date_modified": "2020-09-26T16:01:14.275335Z",
@@ -32,6 +34,8 @@ BOOKMARKS_SINGLE_RESPONSE = {
     "description": "Example description",
     "website_title": "Website title",
     "website_description": "Website description",
+    "is_archived": False,
+    "unread": False,
     "tag_names": ["tag1", "tag2"],
     "date_added": "2020-09-26T09:46:23.006313Z",
     "date_modified": "2020-09-26T16:01:14.275335Z",
@@ -93,7 +97,7 @@ BOOKMARKS_SINGLE_RESPONSE = {
             ["bookmarks", "create", "https://example.com"],
             "aiolinkding.bookmark.BookmarkManager.async_create",
             ["https://example.com"],
-            {"archived": False},
+            {"archived": False, "unread": False},
             BOOKMARKS_SINGLE_RESPONSE,
             json.dumps(BOOKMARKS_SINGLE_RESPONSE),
         ),
@@ -101,7 +105,7 @@ BOOKMARKS_SINGLE_RESPONSE = {
             ["bookmarks", "create", "https://example.com", "-a"],
             "aiolinkding.bookmark.BookmarkManager.async_create",
             ["https://example.com"],
-            {"archived": True},
+            {"archived": True, "unread": False},
             BOOKMARKS_SINGLE_RESPONSE,
             json.dumps(BOOKMARKS_SINGLE_RESPONSE),
         ),
@@ -109,7 +113,7 @@ BOOKMARKS_SINGLE_RESPONSE = {
             ["bookmarks", "create", "https://example.com", "-t", "Example"],
             "aiolinkding.bookmark.BookmarkManager.async_create",
             ["https://example.com"],
-            {"archived": False, "title": "Example"},
+            {"archived": False, "title": "Example", "unread": False},
             BOOKMARKS_SINGLE_RESPONSE,
             json.dumps(BOOKMARKS_SINGLE_RESPONSE),
         ),
@@ -129,6 +133,7 @@ BOOKMARKS_SINGLE_RESPONSE = {
                 "archived": False,
                 "description": "A site description",
                 "title": "Example",
+                "unread": False,
             },
             BOOKMARKS_SINGLE_RESPONSE,
             json.dumps(BOOKMARKS_SINGLE_RESPONSE),
@@ -152,6 +157,7 @@ BOOKMARKS_SINGLE_RESPONSE = {
                 "description": "A site description",
                 "tag_names": ["single-tag"],
                 "title": "Example",
+                "unread": False,
             },
             BOOKMARKS_SINGLE_RESPONSE,
             json.dumps(BOOKMARKS_SINGLE_RESPONSE),
@@ -175,7 +181,16 @@ BOOKMARKS_SINGLE_RESPONSE = {
                 "description": "A site description",
                 "tag_names": ["tag1", "tag2", "tag3"],
                 "title": "Example",
+                "unread": False,
             },
+            BOOKMARKS_SINGLE_RESPONSE,
+            json.dumps(BOOKMARKS_SINGLE_RESPONSE),
+        ),
+        (
+            ["bookmarks", "create", "https://example.com", "--unread"],
+            "aiolinkding.bookmark.BookmarkManager.async_create",
+            ["https://example.com"],
+            {"archived": False, "unread": True},
             BOOKMARKS_SINGLE_RESPONSE,
             json.dumps(BOOKMARKS_SINGLE_RESPONSE),
         ),
@@ -207,7 +222,7 @@ BOOKMARKS_SINGLE_RESPONSE = {
             ["bookmarks", "update", "12", "-u", "https://example.com"],
             "aiolinkding.bookmark.BookmarkManager.async_update",
             [12],
-            {"url": "https://example.com"},
+            {"url": "https://example.com", "unread": False},
             BOOKMARKS_SINGLE_RESPONSE,
             json.dumps(BOOKMARKS_SINGLE_RESPONSE),
         ),
@@ -215,7 +230,7 @@ BOOKMARKS_SINGLE_RESPONSE = {
             ["bookmarks", "update", "12", "-t", "Updated Title"],
             "aiolinkding.bookmark.BookmarkManager.async_update",
             [12],
-            {"title": "Updated Title"},
+            {"title": "Updated Title", "unread": False},
             BOOKMARKS_SINGLE_RESPONSE,
             json.dumps(BOOKMARKS_SINGLE_RESPONSE),
         ),
@@ -223,7 +238,15 @@ BOOKMARKS_SINGLE_RESPONSE = {
             ["bookmarks", "update", "12", "--tags", "different-tag1,different-tag2"],
             "aiolinkding.bookmark.BookmarkManager.async_update",
             [12],
-            {"tag_names": ["different-tag1", "different-tag2"]},
+            {"tag_names": ["different-tag1", "different-tag2"], "unread": False},
+            BOOKMARKS_SINGLE_RESPONSE,
+            json.dumps(BOOKMARKS_SINGLE_RESPONSE),
+        ),
+        (
+            ["bookmarks", "update", "12", "--unread"],
+            "aiolinkding.bookmark.BookmarkManager.async_update",
+            [12],
+            {"unread": True},
             BOOKMARKS_SINGLE_RESPONSE,
             json.dumps(BOOKMARKS_SINGLE_RESPONSE),
         ),
@@ -237,12 +260,3 @@ def test_bookmark_command_api_calls(
         result = runner.invoke(APP, args)
         mocked_api_call.assert_awaited_with(*api_coro_args, **api_coro_kwargs)
     assert stdout_output in result.stdout
-
-
-def test_update_no_options(caplog, runner):
-    """Test that attempting to update a bookmark with no options fails."""
-    runner.invoke(APP, ["bookmarks", "update", "12"])
-    assert (
-        "Cannot update a bookmark with passing at least one option."
-        in caplog.messages[0]
-    )


### PR DESCRIPTION
**Describe what the PR does:**

Linkding 1.12.0 adds [the ability to mark bookmarks as unread](https://github.com/sissbruecker/linkding/pull/304). This PR adds the corresponding functionality to this library.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
