### PR TITLE
Update CI to use GA release of Python 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-rc.2"
+          - "3.11"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
 
       - name: Publish to PyPI
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,55 +1,54 @@
 ---
 repos:
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.6.2
+    rev: 1.7.4
     hooks:
       - id: bandit
         args:
           - --quiet
           - --format=custom
           - --configfile=.bandit.yaml
-        files: ^linkding_cli/.+\.py$
+        files: ^linkding-cli/.+\.py$
   - repo: https://github.com/python/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
         args:
           - --safe
           - --quiet
         language_version: python3
-        files: ^((linkding_cli|tests)/.+)?[^/]+\.py$
+        files: ^((linkding-cli|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
-    rev: v1.16.0
+    rev: v2.2.2
     hooks:
       - id: codespell
         args:
           - --skip="./.*,*.json"
           - --quiet-level=4
-          - -L ba
         exclude_types: [json]
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-bugbear
           - flake8-docstrings
           - pydocstyle
-        files: ^linkding_cli/.+\.py$
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+        files: ^linkding-cli/.+\.py$
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
     hooks:
       - id: isort
         additional_dependencies:
           - toml
-        files: ^(linkding_cli|tests)/.+\.py$
+        files: ^(linkding-cli|tests)/.+\.py$
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.982
     hooks:
       - id: mypy
-        files: ^linkding_cli/.+\.py$
+        files: ^linkding-cli/.+\.py$
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v4.3.0
     hooks:
       - id: check-json
       - id: check-yaml
@@ -60,16 +59,16 @@ repos:
           - --branch=master
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 5.0.2
+    rev: 6.1.1
     hooks:
       - id: pydocstyle
-        files: ^((linkding_cli|tests)/.+)?[^/]+\.py$
+        files: ^((linkding-cli|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.12
+    rev: v0.1.17
     hooks:
       - id: shellcheck
         files: ^script/.+
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.1
+    rev: v3.1.0
     hooks:
       - id: pyupgrade

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
           - --quiet
           - --format=custom
           - --configfile=.bandit.yaml
-        files: ^linkding-cli/.+\.py$
+        files: ^linkding_cli/.+\.py$
   - repo: https://github.com/python/black
     rev: 22.10.0
     hooks:
@@ -17,7 +17,7 @@ repos:
           - --safe
           - --quiet
         language_version: python3
-        files: ^((linkding-cli|tests)/.+)?[^/]+\.py$
+        files: ^((linkding_cli|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2
     hooks:
@@ -34,19 +34,19 @@ repos:
           - flake8-bugbear
           - flake8-docstrings
           - pydocstyle
-        files: ^linkding-cli/.+\.py$
+        files: ^linkding_cli/.+\.py$
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:
       - id: isort
         additional_dependencies:
           - toml
-        files: ^(linkding-cli|tests)/.+\.py$
+        files: ^(linkding_cli|tests)/.+\.py$
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.982
     hooks:
       - id: mypy
-        files: ^linkding-cli/.+\.py$
+        files: ^linkding_cli/.+\.py$
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
@@ -62,7 +62,7 @@ repos:
     rev: 6.1.1
     hooks:
       - id: pydocstyle
-        files: ^((linkding-cli|tests)/.+)?[^/]+\.py$
+        files: ^((linkding_cli|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/gruntwork-io/pre-commit
     rev: v0.1.17
     hooks:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ pip install linkding-cli
 
 `linkding-cli` is currently supported on:
 
-* Python 3.8
 * Python 3.9
 * Python 3.10
 * Python 3.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ packages = [
 [tool.poetry.dependencies]
 "ruamel.yaml" = "^0.17.21"
 aiolinkding = ">=2022.10.0"
-python = ">=3.9.0"
+python = "^3.9.0"
 typer = {extras = ["all"], version = "^0.6.0"}
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ packages = [
 
 [tool.poetry.dependencies]
 "ruamel.yaml" = "^0.17.21"
-aiolinkding = ">=2022.8.0"
+aiolinkding = ">=2022.10.0"
 python = ">=3.9.0"
 typer = {extras = ["all"], version = "^0.6.0"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ disallow_untyped_defs = true
 follow_imports = "silent"
 ignore_missing_imports = true
 no_implicit_optional = true
-python_version = "3.8"
+python_version = "3.10"
 show_error_codes = true
 strict_equality = true
 warn_incomplete_stub = true
@@ -56,7 +56,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -70,7 +69,7 @@ packages = [
 [tool.poetry.dependencies]
 "ruamel.yaml" = "^0.17.21"
 aiolinkding = ">=2022.8.0"
-python = "^3.8.0"
+python = ">=3.9.0"
 typer = {extras = ["all"], version = "^0.6.0"}
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
**Describe what the PR does:**

Happy Python 3.11 release day! This PR updates CI to tests against the GA release. Per our standards of supporting the three most recent versions, this PR also removes official support for anything before 3.9.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
